### PR TITLE
Add dependency requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# Project dependencies
+# eventsourcing library is needed for event sourcing features used in domain and application modules
+# pinned to a modern version known to work with Python 3.11
+
+eventsourcing==9.2.18


### PR DESCRIPTION
## Summary
- list eventsourcing dependency so the example code can run

## Testing
- `python -m unittest test.py` *(fails: ModuleNotFoundError: No module named 'eventsourcing')*

------
https://chatgpt.com/codex/tasks/task_e_6853e13f52fc832782fcba7b9fccb23a